### PR TITLE
fix: Use Template Messages for Buttons

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -537,12 +537,20 @@ export const ValidationHelpers = {
 
 export const ButtonHelpers = {
   sendButtons: async (sock, jid, text, footer, buttons) => {
-    const buttonMessage = {
+    const templateButtons = buttons.map((btn, i) => ({
+      index: i + 1,
+      quickReplyButton: {
+        displayText: btn.buttonText.displayText,
+        id: btn.buttonId
+      }
+    }));
+
+    const templateMessage = {
       text: text,
       footer: footer,
-      buttons: buttons,
-      headerType: 1
+      templateButtons: templateButtons
     };
-    await sock.sendMessage(jid, buttonMessage);
+
+    await sock.sendMessage(jid, templateMessage);
   }
 };


### PR DESCRIPTION
This commit fixes an issue where buttons were not appearing for users. The previous implementation used a button format that is no longer consistently supported by WhatsApp.

This has been resolved by switching to the more reliable "Template Message" format for sending buttons. The `ButtonHelpers.sendButtons` function in `lib/helpers.js` has been updated to construct and send this new message type.

The new implementation is backward-compatible with the existing plugin structure, so no changes were needed in the plugins themselves.