### PR TITLE
Fix: Correctly handle sessionAttempts data in interview plugin

### DIFF
--- a/plugins/interview.js
+++ b/plugins/interview.js
@@ -280,10 +280,17 @@ class GroupSettings {
     this.sessionAttempts = new Map();
   }
 
-  toDB() { return { ...this }; }
+  toDB() {
+    const obj = { ...this };
+    obj.sessionAttempts = Object.fromEntries(this.sessionAttempts); // Convert Map to object
+    return obj;
+  }
+
   static fromDB(obj) {
     const settings = new GroupSettings(obj.groupId);
     Object.assign(settings, obj);
+    // Ensure sessionAttempts is a Map, converting from object if needed
+    settings.sessionAttempts = new Map(Object.entries(obj.sessionAttempts || {}));
     return settings;
   }
 }


### PR DESCRIPTION
The interview plugin was throwing a `TypeError: settings.sessionAttempts.get is not a function` because the `sessionAttempts` Map was not being correctly serialized and deserialized when storing to and retrieving from the database.

This commit fixes the issue by updating the `toDB` and `fromDB` methods in the `GroupSettings` class:
- `toDB` now converts the `sessionAttempts` Map to a plain object before saving.
- `fromDB` now converts the plain object back to a `Map` when loading settings.

This ensures that `sessionAttempts` is always a Map object in memory, resolving the TypeError and allowing the interview command to function correctly.