### PR TITLE
fix: Correct admin authorization logic in owner plugin

### DIFF
--- a/plugins/owner_plugin.js
+++ b/plugins/owner_plugin.js
@@ -401,8 +401,14 @@ export default async function ownerHandler(m, sock, config, bot) {
 
   if (requiredPermission === 'admin' && !isOwner) {
     try {
-      const isAdmin = await OwnerHelpers.isUserAdmin(m.sender.replace('@s.whatsapp.net', ''));
-      if (!isAdmin) return m.reply('❌ You are not authorized to use this command.');
+      const senderPhone = m.sender.replace('@s.whatsapp.net', '');
+      const isDbAdmin = await OwnerHelpers.isUserAdmin(senderPhone);
+      const configAdmins = (config.ADMIN_NUMBERS || '').split(',').map(num => num.trim());
+      const isConfigAdmin = configAdmins.includes(senderPhone);
+
+      if (!isDbAdmin && !isConfigAdmin) {
+        return m.reply('❌ You are not authorized to use this command.');
+      }
     } catch (error) {
       console.error('Error checking admin status:', error);
       return m.reply('❌ Error checking authorization.');


### PR DESCRIPTION
The previous implementation of the admin check in `owner_plugin.js` only verified admins from the database (`OwnerHelpers.isUserAdmin`). This meant that admin numbers specified in the `ADMIN_NUMBERS` environment variable were not being recognized.

This patch updates the authorization logic to check for admins from both the database and the environment configuration, ensuring that all designated admins have the appropriate access.