### PR TITLE
fix: Handle array and string types for ADMIN_NUMBERS

### DIFF
--- a/plugins/owner_plugin.js
+++ b/plugins/owner_plugin.js
@@ -403,7 +403,14 @@ export default async function ownerHandler(m, sock, config, bot) {
     try {
       const senderPhone = m.sender.replace('@s.whatsapp.net', '');
       const isDbAdmin = await OwnerHelpers.isUserAdmin(senderPhone);
-      const configAdmins = (config.ADMIN_NUMBERS || '').split(',').map(num => num.trim());
+
+      let configAdmins = [];
+      if (Array.isArray(config.ADMIN_NUMBERS)) {
+        configAdmins = config.ADMIN_NUMBERS.map(num => String(num).trim());
+      } else if (typeof config.ADMIN_NUMBERS === 'string') {
+        configAdmins = config.ADMIN_NUMBERS.split(',').map(num => num.trim());
+      }
+
       const isConfigAdmin = configAdmins.includes(senderPhone);
 
       if (!isDbAdmin && !isConfigAdmin) {


### PR DESCRIPTION
The previous implementation of the admin check in `owner_plugin.js` assumed that `config.ADMIN_NUMBERS` was a string, which caused a `TypeError` when it was an array.

This patch updates the authorization logic to handle both string and array types for the `config.ADMIN_NUMBERS` value. This prevents the `TypeError` from occurring and ensures that admins from the environment variables are correctly recognized, regardless of the format.