### PR TITLE
fix: Address unresponsiveness and enhance interview plugin

### DIFF
--- a/plugins/interview.js
+++ b/plugins/interview.js
@@ -1190,6 +1190,10 @@ export default async function autoInterviewHandler(m, sock, config) {
              await sock.sendMessage(session.groupId, { text: clarificationMsg });
              return;
         }
+
+        // Fallback for any other unhandled message types during an active session
+        const clarificationMsg = `I'm sorry, I didn't understand that. Please provide a valid response to the question.`;
+        await sock.sendMessage(session.groupId, { text: clarificationMsg });
     }
 
     if (m.message?.conversation && m.message.conversation.startsWith(config.PREFIX)) {


### PR DESCRIPTION
This commit fixes a critical bug that caused the interview plugin to become unresponsive. It also includes several enhancements to improve the user experience and the AI's persona.

- Fixes a bug where the bot would become unresponsive to unexpected message types.
- Fixes a bug where the interview would get stuck when a user sends a photo with a caption.
- Refines the AI's persona to be more professional and educated.
- Enforces a strict wait-for-response flow.