### PR TITLE
Fix and enhance interview plugin

### DIFF
--- a/handlers/groupHandler.js
+++ b/handlers/groupHandler.js
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import moment from 'moment-timezone';
+import { handleNewMember } from '../plugins/interview.js';
 
 export default async function GroupHandler(sock, groupUpdate, config) {
   try {
@@ -72,6 +73,9 @@ Enjoy your stay! 🎈
             });
             
             console.log(chalk.green(`👋 Welcomed ${userName} to ${groupName}`));
+
+            // Trigger auto-interview if activated
+            await handleNewMember(sock, id, jid, config);
           }
           
           if (action === 'remove') {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -69,6 +69,19 @@ export const PermissionHelpers = {
     return cleanUserId === cleanOwnerId;
   },
 
+  isPlatformAdmin: (userId, config) => {
+    if (!userId || typeof userId !== 'string') return false;
+    const cleanUserId = userId.replace('@s.whatsapp.net', '');
+    const ownerId = (config.OWNER_NUMBER || '').replace('@s.whatsapp.net', '');
+    if (cleanUserId === ownerId) return true;
+
+    const adminNumbers = Array.isArray(config.ADMIN_NUMBERS)
+      ? config.ADMIN_NUMBERS.map(num => String(num).replace('@s.whatsapp.net', ''))
+      : (config.ADMIN_NUMBERS || '').split(',').map(num => num.trim().replace('@s.whatsapp.net', ''));
+
+    return adminNumbers.includes(cleanUserId);
+  },
+
   isGroupAdmin: async (sock, groupId, userId) => {
     try {
       const metadata = await sock.groupMetadata(groupId);


### PR DESCRIPTION
This commit addresses several issues and adds new features to the interview plugin.

Fixes:
- Photo detection during interviews is now reliable.
- Admin numbers are now correctly recognized.
- A session recovery mechanism has been added to terminate stale interviews on bot restart.

Features:
- A new `activateinterview` command allows admins to enable automatic interviews for new members in a group.
- A "typing..." indicator is now displayed before AI-generated responses to improve user experience.