### PR TITLE
feat: Refactor interview plugin and enhance plugin manager

### DIFF
--- a/lib/pluginManager.js
+++ b/lib/pluginManager.js
@@ -102,6 +102,8 @@ class PluginManager {
         filename: filename,
         handler: pluginModule.default,
         info: pluginModule.info || { name: filename },
+        initialize: pluginModule.initialize,
+        initialized: false,
         loadTime: Date.now(),
         enabled: true,
         errors: 0,
@@ -317,6 +319,18 @@ class PluginManager {
   async executePlugin(filename, plugin, m, sock, config, bot) {
     const stats = this.pluginStats.get(filename);
     if (!stats) return;
+
+    // Initialize plugin if it has an initializer and hasn't been initialized
+    if (plugin.initialize && !plugin.initialized) {
+      try {
+        plugin.initialize(config);
+        plugin.initialized = true;
+      } catch (error) {
+        console.error(chalk.red(`❌ Failed to initialize plugin ${filename}:`), error.message);
+        plugin.enabled = false; // Disable plugin if initialization fails
+        return;
+      }
+    }
     
     const startTime = Date.now();
     


### PR DESCRIPTION
This commit refactors the `interview.js` plugin to align its admin verification logic with the main bot's standards. It also enhances the `pluginManager` to support a new initialization lifecycle for plugins.

Key changes:

1.  **Enhanced PluginManager**:
    -   `lib/pluginManager.js` now detects and calls an `initialize(config)` function on any plugin that exports one.
    -   This allows plugins to receive the main bot configuration upon loading, making the system more robust and extensible.

2.  **Refactored Interview Plugin**:
    -   `plugins/interview.js` now exports an `initialize` function to receive and store the bot's configuration.
    -   The `isAdmin` function has been refactored to use the stored configuration, removing the need to pass the `config` object through multiple function calls.
    -   All internal calls to `isAdmin` and `handleNewMember` have been updated to reflect the new function signatures.
    -   This change ensures that the interview plugin's admin checks are consistent with the rest of the bot, using the owner and admin numbers from the central config.