### PR TITLE
Fix NaN balance vulnerability in economy plugin

### DIFF
--- a/plugins/economy_plugin.js
+++ b/plugins/economy_plugin.js
@@ -226,6 +226,18 @@ async function initUser(userId) {
       // Backward compatibility - add missing fields (UNCHANGED LOGIC)
       const updates = {};
       let needsUpdate = false;
+
+      // FIX: Check for and correct NaN balances
+      if (isNaN(existingUser.balance)) {
+        updates.balance = 0;
+        needsUpdate = true;
+        console.warn(`Corrected NaN balance for user ${userId}`);
+      }
+      if (isNaN(existingUser.bank)) {
+        updates.bank = 0;
+        needsUpdate = true;
+        console.warn(`Corrected NaN bank balance for user ${userId}`);
+      }
       
       const requiredFields = {
         activeEffects: {},
@@ -599,6 +611,11 @@ async function updateUserData(userId, data) {
 // ✅ REFACTORED: Money functions now use getCollection for direct, safe access.
 // We keep the custom logic for effects, but replace the DB interaction.
 async function addMoney(userId, amount, reason = 'Unknown', applyEffects = true) {
+  // FIX: Failsafe to prevent non-finite numbers from being added
+  if (!Number.isFinite(amount)) {
+    console.error(`Attempted to add invalid amount: ${amount} for user ${userId}`);
+    throw new Error('Invalid amount provided to addMoney');
+  }
   try {
     const user = await getUserData(userId);
     let finalAmount = amount;
@@ -648,6 +665,11 @@ async function addMoney(userId, amount, reason = 'Unknown', applyEffects = true)
 }
 
 async function removeMoney(userId, amount, reason = 'Unknown') {
+  // FIX: Failsafe to prevent non-finite numbers from being removed
+  if (!Number.isFinite(amount)) {
+    console.error(`Attempted to remove invalid amount: ${amount} for user ${userId}`);
+    throw new Error('Invalid amount provided to removeMoney');
+  }
   try {
     const user = await getUserData(userId);
     if (user.balance >= amount) {
@@ -1190,6 +1212,12 @@ async function handleStocks(context, args) {
         
         const buySymbol = args[1].toUpperCase();
         const buyAmount = parseInt(args[2]);
+
+        // FIX: Add robust input validation
+        if (isNaN(buyAmount) || buyAmount <= 0) {
+          await reply('⚠️ *Please provide a valid, positive number for the amount.*');
+          return;
+        }
         
         if (!stocks[buySymbol]) {
           await reply('❌ *Invalid stock symbol*');
@@ -1223,6 +1251,12 @@ async function handleStocks(context, args) {
         
         const sellSymbol = args[1].toUpperCase();
         const sellAmount = parseInt(args[2]);
+
+        // FIX: Add robust input validation
+        if (isNaN(sellAmount) || sellAmount <= 0) {
+            await reply('⚠️ *Please provide a valid, positive number for the amount.*');
+            return;
+        }
         
         if (!stocks[sellSymbol]) {
           await reply('❌ *Invalid stock symbol*');
@@ -2420,6 +2454,12 @@ async function handleCrypto(context, args) {
         
         const buySymbol = args[1].toUpperCase();
         const buyAmount = parseFloat(args[2]);
+
+        // FIX: Add robust input validation
+        if (isNaN(buyAmount) || buyAmount <= 0) {
+          await reply('⚠️ *Please provide a valid, positive number for the amount.*');
+          return;
+        }
         
         if (!cryptoData[buySymbol]) {
           await reply('❌ *Invalid cryptocurrency symbol*');
@@ -2453,6 +2493,12 @@ async function handleCrypto(context, args) {
         
         const sellSymbol = args[1].toUpperCase();
         const sellAmount = parseFloat(args[2]);
+
+        // FIX: Add robust input validation
+        if (isNaN(sellAmount) || sellAmount <= 0) {
+          await reply('⚠️ *Please provide a valid, positive number for the amount.*');
+          return;
+        }
         
         if (!cryptoData[sellSymbol]) {
           await reply('❌ *Invalid cryptocurrency symbol*');


### PR DESCRIPTION
This commit addresses a critical vulnerability where a user's balance could become `NaN`, allowing for unlimited transactions.

The root cause was improper input validation in the `handleStocks` and `handleCrypto` functions. When a non-numeric amount was provided for a sale, the calculation resulted in `NaN`, which was then saved to the user's balance.

The fix is multi-layered:
1.  **Data Correction**: The `initUser` function now checks for `NaN` in `balance` and `bank` fields for existing users and resets them to 0, correcting corrupted data upon load.
2.  **Input Validation**: Added strict validation to `handleStocks` and `handleCrypto` to ensure transaction amounts are valid, positive numbers.
3.  **Failsafe**: Added `Number.isFinite` checks to the core `addMoney` and `removeMoney` functions to prevent any invalid numbers from being processed, protecting against similar future bugs.