### PR TITLE
fix(plugins): correct syntax error in owner_plugin.js

### DIFF
--- a/plugins/owner_plugin.js
+++ b/plugins/owner_plugin.js
@@ -81,22 +81,6 @@ const commands = {
       }
     }
   },
-  // ...other command handlers should follow the same pattern...
-};
-
-// Plugin entrypoint for PluginManager
-export default {
-  info,
-  commands,
-  async onLoad() {
-    // Load settings from DB on startup
-    this.settings = await loadSettings();
-  },
-  async onSave() {
-    // Save settings to DB
-    await saveSettings(this.settings || {});
-  }
-};
 
   stats: {
     name: 'stats',
@@ -401,8 +385,7 @@ export default {
 };
 
 // --- Main Handler ---
-
-export default async function ownerHandler(m, sock, config, bot) {
+async function ownerHandler(m, sock, config, bot) {
   if (!m.body || !m.body.startsWith(config.PREFIX)) return;
 
   const args = m.body.slice(config.PREFIX.length).trim().split(' ');
@@ -466,3 +449,17 @@ export default async function ownerHandler(m, sock, config, bot) {
     await m.reply(`❌ An error occurred while executing the command: ${error.message}`);
   }
 }
+
+// Plugin entrypoint for PluginManager
+export default {
+  info,
+  handler: ownerHandler,
+  async onLoad() {
+    // Load settings from DB on startup
+    this.settings = await loadSettings();
+  },
+  async onSave() {
+    // Save settings to DB
+    await saveSettings(this.settings || {});
+  }
+};


### PR DESCRIPTION
The owner_plugin.js file had a syntax error due to misplaced command handler definitions. The command handlers from 'stats' onwards were defined outside the 'commands' object, causing a loading failure with an 'Unexpected token ':' error.

This commit moves all command handler definitions into the 'commands' object and restructures the plugin export to correctly export the handler function, resolving the syntax error and allowing the plugin to load properly.